### PR TITLE
add checking condition of REMOVE_DEFAULT_SERVER

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -89,6 +89,8 @@ proxy_set_header Proxy "";
 {{ end }}
 
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
+
+{{ if and $.Env.REMOVE_DEFAULT_SERVER (eq $.Env.REMOVE_DEFAULT_SERVER "true") }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;
@@ -113,6 +115,7 @@ server {
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
 }
+{{ end }}
 {{ end }}
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -90,7 +90,7 @@ proxy_set_header Proxy "";
 
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
 
-{{ if and $.Env.REMOVE_DEFAULT_SERVER (eq $.Env.REMOVE_DEFAULT_SERVER "true") }}
+{{ if (not $.Env.REMOVE_DEFAULT_SERVER) }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;


### PR DESCRIPTION
## ゴール
休止金のAPIサーバーのヘルスチェックエラーの解消。

## 背景
休止金のヘルスチェックがエラーになっている原因をサポートに問い合わせたところ、AWSのELB からのヘルスチェックのホストヘッダにはhost名が含まれないため、このNginxの設定だと `server_name _;` にアクセスしてしまうとの連絡があった。
詳細は[こちら](https://milabo.slack.com/files/U02H0QBNWHF/F051U1D8DQD/______)を参照。

## 修正内容

環境変数に `REMOVE_DEFAULT_SERVER` が存在しないときにのみ、デフォルトサーバー定義をするようにテンプレートを修正。
=> `REMOVE_DEFAULT_SERVER` が定義されている場合にはデフォルトのディレクティブを削除したい。 

## 対応検討

サポートからの提案は2点

1. `api.welfare.plus-focus.jp` に `listen 80 default_server;`を追加して、こちらのディレクティブの設定をデフォルトにする
1. サーバーディレクティブの順序を入れ替える

### 1の方法について
APIサーバーのNginxのプロキシ設定は milabo/nginx-proxy(このリポジトリ) にあるNginxテンプレートで設定されている。
VIRTUAL_HOSTという環境変数を設定してしまうと、`$host` が設定されて `$default_server` という変数が空になるため、そうなるとこのテンプレートのままではAWSの方が提案している `listen 80 default_server;` の方法はとれなさそう。
直接書き換えると他のサービスで使っている部分にも影響が出る

### 2の方法について
複数サービスで本番利用しているDockerイメージのため、順番を入れ替えた場合の影響範囲を絞り込めない。
たぶんホスト名が未定義のものの記載位置を変えるだけで問題なさそうではあるが、サーバーディレクティブの順序によってうまく動作している可能性もある。影響範囲の調査も大変になりそう。

### その他の方法
[こちらのIssue](https://github.com/nginx-proxy/nginx-proxy/issues/1182)にあるように`server_name _;` のディレクティブを削除すれば、ヘルスチェックが動作したという報告があった。
環境変数を設定した場合のみ、このディレクティブを削除するのが一番影響範囲は少なさそう。
ただし、`api.welfare.plus-focus.jp` が80ポートのデフォルト設定となってしまうため、ALBのIPへ直接アクセスした場合などの処理も全て引き受けることになってしまう。
とはいえ、現状一番影響範囲を抑えてこのイメージを使用する方法はこれかなーと思っている。

最新の [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy/blob/main/nginx.tmpl) でもディレクティブの定義の順番は変わっておらず、`$default_server` は `$host` が定義されていると空になるため 1 または 2の提案に関する状況は変わらなさそう。

## この後にやること

- [ ] S3のalphaの環境変数を書き換える
  - https://s3.console.aws.amazon.com/s3/object/kocho-deploy?region=ap-northeast-1&prefix=env/
- [ ] alphaの環境での動作確認
- [ ] 実施日程調整
- [ ] 複数台ターゲットグループがある場合は1台ずつ外して、1台ずつ変更を適用してターゲットグループに戻す
  - 変更の適用は環境変数設定をして[起動シェル](https://github.com/milabo/mhlw-kocho/blob/8782560f0d164420a04169f3ce5daf02755cf942/integration/aws/startup/backend-api.sh)を叩く。

## レビュー依頼

- [ ] このPRの方針で問題ないか。もしくは、ヘルスチェックエラーになったままでもいいか。他にいい方法があるか。
- [ ] REMOVE_DEFAULT_SERVER を環境変数(S3バケットのファイルを更新する必要あり)を設定することでディレクティブが消える条件付けの設定があっているか。
- [ ] 手順の抜け漏れや考慮漏れがないか。
